### PR TITLE
Fix a bug of example1 segmentation fault

### DIFF
--- a/src/ParallelBitmapIterator.cpp
+++ b/src/ParallelBitmapIterator.cpp
@@ -62,7 +62,8 @@ void* generateCommaPositionsInThread(void* arg) {
             }
             commabit = commabit & (commabit - 1);
         }
-    }    
+    }
+    return NULL;    
 }
 
 void ParallelBitmapIterator::generateCommaPositionsParallel(long start_pos, long end_pos, int level, long* comma_positions, long& top_comma_positions) {


### PR DESCRIPTION
This bug occurs when thread_num>=2 and gcc optimization>=O1. The reason is that the absent return caused the compiler to incorrectly optimize the judgment statement.

Fix #2